### PR TITLE
replaced deprecated user level in add_menu_page function

### DIFF
--- a/cas-maestro.php
+++ b/cas-maestro.php
@@ -440,7 +440,7 @@ class CAS_Maestro {
 				case 'settings':
 				default:
 					$settings_page = add_options_page(__('CAS Maestro', "CAS_Maestro"), 
-						__('CAS Maestro', "CAS_Maestro"), 8, 
+						__('CAS Maestro', "CAS_Maestro"), 'manage_options', 
 						'wpcas_settings', 
 						array(&$this,'admin_interface'));
 					break;


### PR DESCRIPTION
When debug is active, plugin is currently reporting the following message:
`Notice: has_cap was called with an argument that is deprecated since version 2.0! Usage of user levels by plugins and themes is deprecated. Use roles and capabilities instead.`

Message was a result of the user level set in the [add_menu_page](http://codex.wordpress.org/Function_Reference/add_menu_page) function.

[More Info](https://wordpress.org/support/topic/has_cap-was-called-with-an-argument-that-is-deprecated)
